### PR TITLE
Update to 3.7.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: mattermost-desktop
-version: 3.7.0
+version: 3.7.1
 summary: Open source, private cloud Slack-alternative
 description: |
  Workplace messaging for web, PCs and phones. MIT-licensed. Hundreds of
@@ -12,7 +12,7 @@ confinement: strict
 parts:
   mattermost-desktop:
     plugin: dump
-    source: https://releases.mattermost.com/desktop/3.7.0/mattermost-desktop-3.7.0-linux-amd64.deb
+    source: https://releases.mattermost.com/desktop/3.7.1/mattermost-desktop-3.7.1-linux-amd64.deb
     source-type: deb
     # Correct path to icon.
     prepare: |


### PR DESCRIPTION
'This release contains a security update for Windows, Mac and Linux, and it is highly recommended that users upgrade to this version.' [Link](https://github.com/mattermost/desktop/releases).

Untested. Please merge, push to `edge`, and put a call for testing in the forum (I could do the latter).

@flexiondotorg is there a reason for using the 'unofficial' (they list them on their release page but call them unofficial) Deb packages rather than using `source-tag` and the git repo or using tarball?