### PR TITLE
Add interface so that auto-away works

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,10 +67,6 @@ apps:
       # Correct the TMPDIR path for Chromium Framework/Electron to
       # ensure libappindicator has readable resources
       TMPDIR: $XDG_RUNTIME_DIR
-      # Coerce XDG_CURRENT_DESKTOP to Unity so that App Indicators
-      # are used and do not fall back to Notification Area applets
-      # or disappear completely.
-      XDG_CURRENT_DESKTOP: Unity
       # Fallback to XWayland if running in a Wayland session.
       DISABLE_WAYLAND: 1
     plugs:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,9 +77,11 @@ apps:
       - browser-support
       - gsettings
       - home
+      - login-session-observe
       - network
       - network-bind
       - opengl
       - pulseaudio
       - removable-media
+      - screen-inhibit-control
       - unity7


### PR DESCRIPTION
This pull request adds the `login-session-observe` and `screen-inhibit-control` interface so that idle users will have their status changed to "away".

Also drop the coercion of `XDG_CURRENT_DESKTOP` since it is no longer required.