### PR TITLE
Migrate to core20

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: mattermost-desktop
 version: 4.6.1
-base: core18
+base: core20
 summary: Open source, private cloud Slack-alternative
 description: |
   Mattermost is secure workplace messaging from behind your firewall.
@@ -51,15 +51,15 @@ parts:
   cleanup:
     after: [mattermost-desktop]
     plugin: nil
-    build-snaps: [ gnome-3-28-1804 ]
+    build-snaps: [ gnome-3-38-2004 ]
     override-prime: |
         set -eux
-        cd /snap/gnome-3-28-1804/current
+        cd /snap/gnome-3-38-2004/current
         find . -type f,l -exec rm -f $SNAPCRAFT_PRIME/{} \;
 
 apps:
   mattermost-desktop:
-    extensions: [gnome-3-28]
+    extensions: [gnome-3-38]
     command: opt/Mattermost/mattermost-desktop --no-sandbox
     desktop: usr/share/applications/mattermost-desktop.desktop
     autostart: mattermost-desktop.desktop


### PR DESCRIPTION
Tested on my workstation using `snapcraft` from edge revision 6002. This can't land until pr-3427 on snapcraft lands - the new extension. 