### PR TITLE
Add the 'process-control' interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
     snap install mattermost-desktop
     sudo snap connect mattermost-desktop:removable-media
+    sudo snap connect mattermost-desktop:process-control
 
 ([Don't have snapd installed?](https://snapcraft.io/docs/core/install))
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 
     snap install mattermost-desktop
     sudo snap connect mattermost-desktop:removable-media
-    sudo snap connect mattermost-desktop:process-control
 
 ([Don't have snapd installed?](https://snapcraft.io/docs/core/install))
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -85,3 +85,4 @@ apps:
       - screen-inhibit-control
       - unity7
       - camera
+      - process-control


### PR DESCRIPTION
This PR is mostly here for discussion. It adds the `process-control` interface to the snap, and some instructions to connect it. 

It solves a problem on my machine at least, where my kernel log gets flooded with messages like the following:

```
[ 4753.457736] audit: type=1326 audit(1631654267.163:3125): auid=1000 uid=1000 gid=1000 ses=3 subj=snap.mattermost-desktop.mattermost-desktop pid=157459 comm="mattermost-desk" exe="/snap/mattermost-desktop/379/opt/Mattermost/mattermost-desktop" sig=0 arch=c000003e syscall=203 compat=0 ip=0x7f3e636d7c7f code=0x50000
[ 4753.457822] audit: type=1326 audit(1631654267.163:3126): auid=1000 uid=1000 gid=1000 ses=3 subj=snap.mattermost-desktop.mattermost-desktop pid=157459 comm="mattermost-desk" exe="/snap/mattermost-desktop/379/opt/Mattermost/mattermost-desktop" sig=0 arch=c000003e syscall=203 compat=0 ip=0x7f3e636d7c7f code=0x50000
[ 4754.099602] audit: type=1326 audit(1631654267.807:3127): auid=1000 uid=1000 gid=1000 ses=3 subj=snap.mattermost-desktop.mattermost-desktop pid=157459 comm="mattermost-desk" exe="/snap/mattermost-desktop/379/opt/Mattermost/mattermost-desktop" sig=0 arch=c000003e syscall=203 compat=0 ip=0x7f3e636d7c7f code=0x50000
[ 4754.099789] audit: type=1326 audit(1631654267.807:3128): auid=1000 uid=1000 gid=1000 ses=3 subj=snap.mattermost-desktop.mattermost-desktop pid=157459 comm="mattermo:gdrv0" exe="/snap/mattermost-desktop/379/opt/Mattermost/mattermost-desktop" sig=0 arch=c000003e syscall=203 compat=0 ip=0x7f3e636d7c7f code=0x50000
```

Doing some digging, syscall 203 is in fact sched_setaffinity. I ran `strace` to confirm:

```
❯ sudo strace -p 157459 -e sched_setaffinity
strace: Process 157459 attached
sched_setaffinity(157516, 128, [12, 13, 14, 15, 16, 17]) = -1 EPERM (Operation not permitted)
sched_setaffinity(157478, 128, [12, 13, 14, 15, 16, 17]) = -1 EPERM (Operation not permitted)
sched_setaffinity(157516, 128, [12, 13, 14, 15, 16, 17]) = -1 EPERM (Operation not permitted)
sched_setaffinity(157516, 128, [6, 7, 8, 9, 10, 11]) = -1 EPERM (Operation not permitted)
sched_setaffinity(157516, 128, [6, 7, 8, 9, 10, 11]) = -1 EPERM (Operation not permitted)
sched_setaffinity(157516, 128, [18, 19, 20, 21, 22, 23]) = -1 EPERM (Operation not permitted)
sched_setaffinity(157516, 128, [18, 19, 20, 21, 22, 23]) = -1 EPERM (Operation not permitted)
sched_setaffinity(157516, 128, [18, 19, 20, 21, 22, 23]) = -1 EPERM (Operation not permitted)
sched_setaffinity(157516, 128, [18, 19, 20, 21, 22, 23]) = -1 EPERM (Operation not permitted)
sched_setaffinity(157516, 128, [6, 7, 8, 9, 10, 11]) = -1 EPERM (Operation not permitted)
sched_setaffinity(157516, 128, [12, 13, 14, 15, 16, 17]) = -1 EPERM (Operation not permitted)
sched_setaffinity(157516, 128, [0, 1, 2, 3, 4, 5]) = -1 EPERM (Operation not permitted)
sched_setaffinity(157516, 128, [12, 13, 14, 15, 16, 17]) = -1 EPERM (Operation not permitted)
sched_setaffinity(157516, 128, [12, 13, 14, 15, 16, 17]) = -1 EPERM (Operation not permitted)
```
