### PR TITLE
Bump to 5.1.0; Add the shared-memory interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -71,7 +71,7 @@ apps:
       # Fallback to XWayland if running in a Wayland session.
       DISABLE_WAYLAND: 1
     plugs:
-      - browser-support
+      - browser-sandbox
       - gsettings
       - home
       - login-session-observe
@@ -85,3 +85,8 @@ apps:
       - screen-inhibit-control
       - unity7
       - camera
+
+plugs:
+  browser-sandbox:
+    interface: browser-support
+    allow-sandbox: true

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,3 +90,4 @@ plugs:
   browser-sandbox:
     interface: browser-support
     allow-sandbox: true
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -61,7 +61,7 @@ parts:
 apps:
   mattermost-desktop:
     extensions: [gnome-3-38]
-    command: opt/Mattermost/mattermost-desktop
+    command: opt/Mattermost/mattermost-desktop --no-sandbox
     desktop: usr/share/applications/mattermost-desktop.desktop
     autostart: mattermost-desktop.desktop
     environment:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -71,6 +71,7 @@ apps:
       # Fallback to XWayland if running in a Wayland session.
       DISABLE_WAYLAND: 1
     plugs:
+      - shmem
       - browser-support
       - gsettings
       - home

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -71,7 +71,7 @@ apps:
       # Fallback to XWayland if running in a Wayland session.
       DISABLE_WAYLAND: 1
     plugs:
-      - browser-sandbox
+      - browser-support
       - gsettings
       - home
       - login-session-observe
@@ -85,9 +85,8 @@ apps:
       - screen-inhibit-control
       - unity7
       - camera
-
+      
 plugs:
-  browser-sandbox:
-    interface: browser-support
-    allow-sandbox: true
-
+  shmem:
+    interface: shared-memory
+    private: true

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: mattermost-desktop
-version: 5.0.2
+version: 5.1.0
 base: core20
 summary: Open source, private cloud Slack-alternative
 description: |
@@ -17,7 +17,6 @@ compression: lzo
 
 architectures:
   - build-on: amd64
-  - build-on: i386
 
 parts:
   bsi-trigger: # A non-built part, only used to trigger builds in build.snapcraft.io on upstream changes
@@ -37,8 +36,7 @@ parts:
     after: [libappindicator]
     plugin: dump
     source:
-      - on amd64: https://releases.mattermost.com/desktop/$SNAPCRAFT_PROJECT_VERSION/mattermost-desktop-$SNAPCRAFT_PROJECT_VERSION-linux-amd64.deb
-      - on i386: https://releases.mattermost.com/desktop/$SNAPCRAFT_PROJECT_VERSION/mattermost-desktop-$SNAPCRAFT_PROJECT_VERSION-linux-i386.deb
+      - on amd64: https://releases.mattermost.com/desktop/$SNAPCRAFT_PROJECT_VERSION/mattermost-desktop_$SNAPCRAFT_PROJECT_VERSION-1_amd64.deb
     source-type: deb
     override-build: |
       snapcraftctl build
@@ -52,16 +50,16 @@ parts:
   cleanup:
     after: [mattermost-desktop]
     plugin: nil
-    build-snaps: [ gnome-3-38-2004 ]
+    build-snaps: [gnome-3-38-2004]
     override-prime: |
-        set -eux
-        cd /snap/gnome-3-38-2004/current
-        find . -type f,l -exec rm -f $SNAPCRAFT_PRIME/{} \;
+      set -eux
+      cd /snap/gnome-3-38-2004/current
+      find . -type f,l -exec rm -f $SNAPCRAFT_PRIME/{} \;
 
 apps:
   mattermost-desktop:
     extensions: [gnome-3-38]
-    command: opt/Mattermost/mattermost-desktop --no-sandbox
+    command: opt/Mattermost/mattermost-desktop --no-sandbox --disable-seccomp-filter-sandbox
     desktop: usr/share/applications/mattermost-desktop.desktop
     autostart: mattermost-desktop.desktop
     environment:
@@ -86,7 +84,7 @@ apps:
       - screen-inhibit-control
       - unity7
       - camera
-      
+
 plugs:
   shmem:
     interface: shared-memory


### PR DESCRIPTION
This PR is a draft to address the issues in the following thread: https://forum.snapcraft.io/t/call-for-testing-mattermost-desktop-on-core20/26629/2

Essentially, with the `core20` release now on `latest/edge`, the `mattermost-desktop` was failing to start for a lack of sandbox. This change reflects a similar approach to how the `brave` snap works, and the following solves the problem on my machine:

```
snapcraft --use-lxd
sudo snap install ./mattermost-desktop_4.7.2_amd64.snap --dangerous
sudo snap connect mattermost-desktop:browser-sandbox
```

I suspect this will have knock-on effects for autoconnecting interfaces

Fixes #44
Fixes #45 
Fixes #49 
Fixes #50 