### PR TITLE
Wayland Support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,8 +66,6 @@ apps:
       # Correct the TMPDIR path for Chromium Framework/Electron to
       # ensure libappindicator has readable resources
       TMPDIR: $XDG_RUNTIME_DIR
-      # Fallback to XWayland if running in a Wayland session.
-      DISABLE_WAYLAND: 1
     plugs:
       - shmem
       - browser-support


### PR DESCRIPTION
**BLUF**: Defaulting to Wayland is probably a bit premature right now, but this PR should be safe to merge to allow people to experiment if they wish.

Experimenting with enabling Wayland. You can test by building the snap on this branch, installing and:

```
 $ mattermost-desktop --enable-features=UseOzonePlatform --ozone-platform=wayland --no-sandbox --disable-seccomp-filter-sandbox
```

Currently, the window draws and seems to function fine, but has no window decorations for me (on 22.04):

![image](https://user-images.githubusercontent.com/668505/173059614-a2cc47be-038e-4105-9fa5-52f348d0bdad.png)