### PR TITLE
Bump to 5.1.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: mattermost-desktop
-version: 5.1.0
+version: 5.1.1-rc1
 base: core20
 summary: Open source, private cloud Slack-alternative
 description: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: mattermost-desktop
-version: 5.1.1-rc1
+version: 5.1.1
 base: core20
 summary: Open source, private cloud Slack-alternative
 description: |


### PR DESCRIPTION
Upstream release: https://github.com/mattermost/desktop/releases/tag/v5.1.1-rc1