### PR TITLE
Dropped libappindicator part, provided by platform

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,17 +23,7 @@ parts:
     plugin: nil
     source: https://github.com/mattermost/desktop.git
 
-  libappindicator:
-    plugin: nil
-    stage-packages:
-      - libappindicator3-1
-    prime:
-      - usr/lib/$CRAFT_ARCH_TRIPLET/libdbusmenu*.so*
-      - usr/lib/$CRAFT_ARCH_TRIPLET/libappindicator*.so*
-      - usr/lib/$CRAFT_ARCH_TRIPLET/libindicator*.so*
-
   mattermost-desktop:
-    after: [libappindicator]
     plugin: nil
     # TODO(jnsgruk): Reenable the dump plugin once snapcraft 7.1.0 supports the deb source type again
     # plugin: dump


### PR DESCRIPTION
Dropped libappindicator part, it ended up a noop as it was getting wiped by the cleanup