### PR TITLE
Bump to Mattermost Desktop 5.2.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: mattermost-desktop
-version: 5.1.1
+version: 5.2.0
 base: core22
 summary: Open source, private cloud Slack-alternative
 description: |


### PR DESCRIPTION
Follow the upstream [release](https://github.com/mattermost/desktop/releases/tag/v5.2.0) of Mattermost 5.2.0