### PR TITLE
chore: bump version to 5.2.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: mattermost-desktop
-version: 5.2.1
+version: 5.2.2
 base: core22
 summary: Open source, private cloud Slack-alternative
 description: |


### PR DESCRIPTION
Bumps Mattermost to 5.2.2

Diff against upstream from [5.2.1 to 5.2.2](https://github.com/mattermost/desktop/compare/v5.2.1...v5.2.2)

Release notes: https://docs.mattermost.com/install/desktop-app-changelog.html#id1