### PR TITLE
Attempt to fix segfault due to libappindicator.so

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,16 +24,12 @@ parts:
     source: https://github.com/mattermost/desktop.git
 
   mattermost-desktop:
-    plugin: nil
-    # TODO(jnsgruk): Reenable the dump plugin once snapcraft 7.1.0 supports the deb source type again
-    # plugin: dump
-    # source: https://releases.mattermost.com/desktop/$SNAPCRAFT_PROJECT_VERSION/mattermost-desktop_$SNAPCRAFT_PROJECT_VERSION-1_amd64.deb
-    # source-type: deb
+    plugin: dump
+    source: https://releases.mattermost.com/desktop/$SNAPCRAFT_PROJECT_VERSION/mattermost-desktop_$SNAPCRAFT_PROJECT_VERSION-1_amd64.deb
+    source-type: deb
     build-packages: [wget, ca-certificates]
     override-build: |
-      # craftctl default
-      wget -qO mattermost.deb https://releases.mattermost.com/desktop/$SNAPCRAFT_PROJECT_VERSION/mattermost-desktop_$SNAPCRAFT_PROJECT_VERSION-1_amd64.deb
-      dpkg-deb -xv mattermost.deb $CRAFT_PART_INSTALL/
+      craftctl default
       sed -i 's|Icon=mattermost-desktop|Icon=/usr/share/icons/hicolor/256x256/apps/mattermost-desktop.png|' ${CRAFT_PART_INSTALL}/usr/share/applications/mattermost-desktop.desktop
     prime:
       - -opt/Mattermost/chrome-sandbox

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,6 +37,7 @@ parts:
       - libnspr4
       - libnss3
       - libxss1
+      - libappindicator3-1
   cleanup:
     after: [mattermost-desktop]
     plugin: nil
@@ -44,7 +45,7 @@ parts:
     override-prime: |
       set -eux
       cd /snap/gnome-42-2204/current
-      find . -type f,l -exec rm -f $CRAFT_PRIME/{} \;
+      find . -type f,l \( ! -iname "*appindicator3.so*" \) -print -exec rm -f $CRAFT_PRIME/{} \;
 
 apps:
   mattermost-desktop:


### PR DESCRIPTION
This is a patch to attempt to fix #66.

It seems the app is segfaulting due to trying to access libappindicator. As far as I can tell, we're cleaning that up from the snap in the `cleanup` stage. This is my first attempt at troubleshooting this...

Fixes #66
