### PR TITLE
chore: bump mattermost to 5.3.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: mattermost-desktop
-version: 5.2.2
+version: 5.3.1
 base: core22
 summary: Open source, private cloud Slack-alternative
 description: |


### PR DESCRIPTION
Follow [upstream release](https://github.com/mattermost/desktop/releases/tag/v5.3.1) of Mattermost v5.3.1