### PR TITLE
chore: bump version to 5.4.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: mattermost-desktop
-version: 5.3.1
+version: 5.4.0
 base: core22
 summary: Open source, private cloud Slack-alternative
 description: |


### PR DESCRIPTION
Bump the version of Mattermost to the recently released 5.4.0.