### PR TITLE
 Add support for arm64 architecture in addition to amd64, as supported by upstream deb availability

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,9 @@ compression: lzo
 
 architectures:
   - build-on: amd64
+    build-for: amd64
+  - build-on: arm64
+    build-for: arm64
 
 parts:
   bsi-trigger: # A non-built part, only used to trigger builds in build.snapcraft.io on upstream changes
@@ -25,7 +28,7 @@ parts:
 
   mattermost-desktop:
     plugin: dump
-    source: https://releases.mattermost.com/desktop/$SNAPCRAFT_PROJECT_VERSION/mattermost-desktop_$SNAPCRAFT_PROJECT_VERSION-1_amd64.deb
+    source: https://releases.mattermost.com/desktop/$SNAPCRAFT_PROJECT_VERSION/mattermost-desktop_$SNAPCRAFT_PROJECT_VERSION-1_$SNAPCRAFT_TARGET_ARCH.deb
     source-type: deb
     build-packages: [wget, ca-certificates]
     override-build: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,9 +17,7 @@ compression: lzo
 
 architectures:
   - build-on: amd64
-    build-for: amd64
   - build-on: arm64
-    build-for: arm64
 
 parts:
   bsi-trigger: # A non-built part, only used to trigger builds in build.snapcraft.io on upstream changes


### PR DESCRIPTION
Upstream releases.mattermost.com also provides an upstream arm64 deb in addition to amd64.

Ive been maintaining an unofficial --channel=edge snap of my own purely for my own use on Raspberry Pi and Ubuntu Asahi for a while now (mattermost-desktop-moon127) but a few other folk have asked about it and Jon suggested I work up a PR to add this to the more official snap on the store.

This PR works for launchpad builds via "snapcraft remote-build" and the resulting snaps have been tested on amd64 and arm64 test targets.