### PR TITLE
chore: mattermost-desktop 5.5.0 -> 5.5.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: mattermost-desktop
-version: 5.5.0
+version: 5.5.1
 base: core22
 summary: Open source, private cloud Slack-alternative
 description: |


### PR DESCRIPTION
Bumps version to follow upstream release: https://github.com/mattermost/desktop/releases/tag/v5.5.1