### PR TITLE
ci: use latest snapcrafters actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"

--- a/.github/testing-issue-template.md
+++ b/.github/testing-issue-template.md
@@ -1,0 +1,37 @@
+---
+title: Call for testing `{{ env.SNAP_NAME }}`
+labels: testing
+---
+
+A new version ({{ env.version }}) of `{{ env.SNAP_NAME }}` was just pushed to the `{{ env.CHANNEL }}` channel [in the snap store](https://snapcraft.io/{{ env.SNAP_NAME }}). The following revisions are available.
+
+| CPU architecture | Revision                 |
+|------------------|--------------------------|
+| amd64            | {{ env.revision_amd64 }} |
+| arm64            | {{ env.revision_arm64 }} |
+
+## How to test it
+
+1. Stop the application if it was already running
+1. Upgrade to this version by running
+
+   ```shell
+   snap refresh {{ env.SNAP_NAME }} --{{ env.CHANNEL }}
+   ```
+
+1. Start the app and test it out.
+1. Finally, add a comment below explaining whether this app is working, and **include the output of the following command**.
+
+   ```shell
+   snap version; lscpu | grep Architecture; snap info {{ env.SNAP_NAME }} | grep installed
+   ```
+
+## How to release it
+
+Maintainers can promote this to stable by commenting `/promote <rev>[,<rev>] stable [done]`.
+
+> For example
+>
+> * To promote a single revision, run `/promote 34 stable`
+> * To promote multiple revisions, run `/promote 34,35 stable`
+> * To promote a revision and close the issue, run `/promote 34,35 stable done`

--- a/.github/workflows/snap-store-promote-to-stable.yml
+++ b/.github/workflows/snap-store-promote-to-stable.yml
@@ -1,0 +1,89 @@
+name: 📦 Promote to stable
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  issues: write
+
+env:
+  SNAP_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  promote:
+    environment: "Candidate Branch"
+    runs-on: ubuntu-latest
+    if: |
+      ( !github.event.issue.pull_request )
+      && contains(github.event.comment.body, '/promote ')
+      && contains(github.event.*.labels.*.name, 'testing')
+    steps:
+      - id: command
+        uses: xt0rted/slash-command-action@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          command: promote
+          reaction: "true"
+          reaction-type: "eyes"
+          allow-edits: "false"
+          permission-level: write
+      - id: promote
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_STABLE }}
+        run: |
+          echo "The command was '${{ steps.command.outputs.command-name }}' with arguments '${{ steps.command.outputs.command-arguments }}'"
+          arguments=(${{ steps.command.outputs.command-arguments }})
+          revision=${arguments[0]}
+          channel=${arguments[1]}
+          done=${arguments[2]}
+
+          # Validation checks
+          re='^[0-9]+([,][0-9]+)*$'
+          if [[ ! "$revision" =~ $re ]]; then
+            echo "revision must be a number or a comma seperated list of numbers, not '$revision'!"
+            exit 1
+          fi
+          if [[ "$channel" != "stable"  ]]; then
+            echo "I can only promote to stable, not '$channel'!"
+            exit 1
+          fi
+          if [[ -n "$done" && "$done" != "done"  ]]; then
+            echo "The third argument should be 'done' or empty"
+            exit 1
+          fi
+
+          # Install Snapcraft
+          sudo snap install --classic snapcraft
+          sudo chown root:root /
+
+          # Iterate over each specified revision and release
+          revs=$(echo $revision | tr "," "\n")
+          released_revs=()
+
+          for r in $revs; do
+            snapcraft release $SNAP_NAME "$r" "$channel"
+            released_revs+="$r"
+          done
+
+          echo "revisions=${released_revs[@]}" >> $GITHUB_OUTPUT
+          echo "channel=$channel" >> $GITHUB_OUTPUT
+          echo "done=$done" >> $GITHUB_OUTPUT
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'The following revisions were released to the `${{ steps.promote.outputs.channel }}` channel: `${{ steps.promote.outputs.revisions }}`'
+            })          
+            if ("${{ steps.promote.outputs.done }}" === "done") {
+              github.rest.issues.update({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'closed'
+              })
+            }

--- a/.github/workflows/snap-store-publish-to-candidate.yml
+++ b/.github/workflows/snap-store-publish-to-candidate.yml
@@ -1,0 +1,98 @@
+name: 📦 Publish to candidate
+
+on:
+  # Run the workflow each time new commits are pushed to the candidate branch. 
+  push:
+    branches: [ "candidate" ]
+  # Allow the workflow to be started manually from the Actions tab.
+  workflow_dispatch:
+  # Allow the workflow to be started by another workflow.
+  workflow_call:
+    secrets:
+      SNAP_STORE_CANDIDATE:
+        required: true
+      LP_BUILD_SECRET:
+        required: true
+
+# Permissions for GITHUB_TOKEN
+permissions:
+  contents: read
+  issues: write
+
+env:
+  # Use the name of the repo as the name of the snap
+  SNAP_NAME: ${{ github.event.repository.name }}
+  # Hardcoded git branch and Snap Store channel channel
+  CHANNEL: 'candidate'
+
+jobs:
+  build:
+    name: "Build & publish"
+    environment: "Candidate Branch"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture: ['amd64', 'arm64']
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.CHANNEL }}
+
+      - name: Setup snapcraft
+        env:
+          LP_BUILD_SECRET: ${{ secrets.LP_BUILD_SECRET }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_CANDIDATE }}
+        run: |
+          sudo snap install snapcraft --classic
+          
+          # Setup Launchpad credentials
+          mkdir -p ~/.local/share/snapcraft/provider/launchpad
+          echo "$LP_BUILD_SECRET" > ~/.local/share/snapcraft/provider/launchpad/credentials
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "Github Actions"
+
+      - name: Remote build the snap
+        id: build
+        env:
+          ARCHITECTURE: ${{ matrix.architecture }}
+        run : |
+          snapcraft remote-build --launchpad-accept-public-upload --build-for=${ARCHITECTURE}
+
+          version="$(cat snap/snapcraft.yaml | yq -r '.version')"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "snap=mattermost-desktop_${version}_${ARCHITECTURE}.snap" >> "$GITHUB_OUTPUT"
+
+      - name: Review the built snap
+        uses: diddlesnaps/snapcraft-review-action@v1
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          isClassic: 'false'
+
+      - name: Publish the built snap
+        id: publish
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_CANDIDATE }}
+          SNAP_NAME: ${{ steps.build.outputs.snap }}
+          ARCHITECTURE: ${{ matrix.architecture }}
+        run: |
+          rev=$(snapcraft push $SNAP_NAME --release=$CHANNEL)
+          echo "revision_${ARCHITECTURE}=${rev}" >> $GITHUB_OUTPUT
+    outputs: 
+      revision_amd64: ${{ steps.publish.outputs.revision_amd64 }}
+      revision_arm64: ${{ steps.publish.outputs.revision_arm64 }}
+      version: ${{ steps.build.outputs.version }}
+  create_issue:
+    name: "Create call for testing"
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          revision_amd64: ${{ needs.build.outputs.revision_amd64 }}
+          revision_arm64: ${{ needs.build.outputs.revision_arm64 }}
+          version: ${{ needs.build.outputs.version }}
+        with:
+          filename: .github/testing-issue-template.md

--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -1,0 +1,40 @@
+name: 🔄 Sync version with upstream
+
+on:
+  # Runs at 10:00 UTC every day
+  schedule:
+    - cron:  '0 10 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+
+jobs:
+  sync-version:
+    name: "Update snapcraft.yaml"
+    environment: "Candidate Branch"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
+      - name: Fetch release version
+        run: |
+          VERSION=$(
+            curl -sL https://api.github.com/repos/mattermost/desktop/releases | 
+            jq .  | grep tag_name | grep -v beta | grep -v rc | head -n 1 | cut -d'"' -f4 | tr -d 'v'
+          )
+          sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml
+      - name: Check for modified files
+        id: git-check
+        run: |
+          MODIFIED=$([ -z "`git status --porcelain`" ] && echo "false" || echo "true")
+          echo "modified=$MODIFIED" >> $GITHUB_OUTPUT
+      - name: Commit latest release version
+        if: steps.git-check.outputs.modified == 'true'
+        run: |
+          git config --global user.name 'Snapcrafters Bot'
+          git config --global user.email 'merlijn.sebrechts+snapcrafters-bot@gmail.com'
+          git commit -am "Automatic sync to latest release"
+          git push
+    outputs:
+      modified: ${{ steps.git-check.outputs.modified }}


### PR DESCRIPTION
Opened in favour of #70. Brings over the latest actions as per the signal-desktop snap.

Also configures dependabot to automatically bump Github Actions each month.
