### PR TITLE
ci: port auto-screenshot and ci changes from signal-desktop

### DIFF
--- a/.github/testing-issue-template.md
+++ b/.github/testing-issue-template.md
@@ -5,12 +5,13 @@ labels: testing
 
 A new version ({{ env.version }}) of `{{ env.SNAP_NAME }}` was just pushed to the `{{ env.CHANNEL }}` channel [in the snap store](https://snapcraft.io/{{ env.SNAP_NAME }}). The following revisions are available.
 
-| CPU architecture | Revision                 |
-|------------------|--------------------------|
-| amd64            | {{ env.revision_amd64 }} |
-| arm64            | {{ env.revision_arm64 }} |
+{{ env.table }}
 
-## How to test it
+## Automated screenshots
+
+The snap will be installed in a VM automatically; screenshots will be posted as a comment on this issue shortly.
+
+## How to test it manually
 
 1. Stop the application if it was already running
 1. Upgrade to this version by running
@@ -32,6 +33,12 @@ Maintainers can promote this to stable by commenting `/promote <rev>[,<rev>] sta
 
 > For example
 >
-> * To promote a single revision, run `/promote 34 stable`
-> * To promote multiple revisions, run `/promote 34,35 stable`
-> * To promote a revision and close the issue, run `/promote 34,35 stable done`
+> - To promote a single revision, run `/promote <rev> stable`
+> - To promote multiple revisions, run `/promote <rev>,<rev> stable`
+> - To promote a revision and close the issue, run `/promote <rev>,<rev> stable done`
+
+You can promote all revisions that were just built with:
+
+```
+/promote {{ env.revisions }} stable done
+```

--- a/.github/vmctl
+++ b/.github/vmctl
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Default VM attributes - tuned for Github Actions runners by default
+VM_NAME="${VM_NAME:-test-vm}"
+VM_SERIES="${VM_SERIES:-22.04}"
+VM_CPUS="${VM_CPUS:=1}"
+VM_MEM_GIB="${VM_MEM_GIB:=6}"
+VM_DISK_GIB="${VM_DISK_GIB:=12}"
+
+build_runner_script() {
+  vmctl_runner="$(mktemp)"
+  chmod +x "$vmctl_runner"
+  cat <<-EOF > "$vmctl_runner"
+#!/usr/bin/env bash
+
+export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
+export WAYLAND_DISPLAY=wayland-0
+export DISPLAY=:0.0
+export HOME=/home/ubuntu
+
+exec "\$@"
+EOF
+
+  echo "$vmctl_runner"
+}
+
+# If we're on a Github Actions Runner, enable KVM.
+enable_kvm_gha() {
+  if [[ -x "${GITHUB_ACTIONS:-}" ]]; then
+    echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger --name-match=kvm
+  fi
+}
+
+# Starts a desktop VM and waits for the agent to be running inside.
+prepare_vm() {
+  # Start the VM
+  lxc launch "images:ubuntu/${VM_SERIES}/desktop" "${VM_NAME}" --vm \
+    -c limits.cpu="${VM_CPUS}" -c limits.memory="${VM_MEM_GIB}GiB" -d root,size="${VM_DISK_GIB}GiB"
+
+  # Wait for the VM agent to be running
+  while ! lxc exec test-vm -- cat /etc/hostname &>/dev/null; do 
+    sleep 2
+  done
+
+  # Push script runner into the VM
+  lxc file push "$(build_runner_script)" test-vm/bin/vmctl-runner
+  lxc exec test-vm -- chmod 755 /bin/vmctl-runner
+
+  # Install gnome-screenshot
+  lxc exec test-vm -- apt-get update
+  lxc exec test-vm -- apt-get install -y gnome-screenshot
+
+  # Kill the gnome initial setup wizard
+  pid="$(lxc exec test-vm -- pidof gnome-initial-setup)"
+  lxc exec test-vm -- kill -9 "$pid"
+}
+
+# Exec a command in the VM using the wrapper.
+exec_in_vm() {
+  lxc exec test-vm -- sudo -u ubuntu bash -c "/bin/vmctl-runner $@"
+}
+
+# Takes a screenshot of the full screen and pulls the file back from the VM to a file
+# named "screenshot-screen.png", and uploads to imgur, returning the URL
+screenshot_full() {
+  # Take a screenshot of the whole screen in the VM
+  exec_in_vm "gnome-screenshot -f /home/ubuntu/screen.png"
+  # Pull the screenshot back to the host
+  lxc file pull test-vm/home/ubuntu/screen.png screenshot-screen.png
+}
+
+# Takes a screenshot of the active window and pulls the file back from the VM to a file
+# named "screenshot-window.png", and uploads to imgur, returning the URL
+screenshot_window() {
+  # Take a screenshot of the active window in the VM
+  exec_in_vm "gnome-screenshot -w -f /home/ubuntu/window.png"
+  # Pull the screenshot back to the host
+  lxc file pull test-vm/home/ubuntu/window.png screenshot-window.png
+}
+
+# Print the usage statement and exit the program
+usage() {
+  echo "Usage: vmctl [prepare | push-snap <file> | exec <string> | screenshot-full | screenshot-window"]
+  exit 1
+}
+
+# Parse the subcommand and exit if empty, printing the usage
+command="${1:-}"; shift
+if [[ -z "$command" ]]; then
+  usage
+fi
+
+case "$command" in
+  "prepare")
+    enable_kvm_gha
+    prepare_vm
+    ;;
+  "exec")
+    exec_in_vm "$@"
+    ;;
+  "screenshot-full")
+    screenshot_full
+    ;;
+  "screenshot-window")
+    screenshot_window
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/.github/workflows/snap-store-promote-to-stable.yml
+++ b/.github/workflows/snap-store-promote-to-stable.yml
@@ -64,7 +64,7 @@ jobs:
 
           for r in $revs; do
             snapcraft release $SNAP_NAME "$r" "$channel"
-            released_revs+="$r"
+            released_revs+=("$r")
           done
 
           echo "revisions=${released_revs[@]}" >> $GITHUB_OUTPUT

--- a/.github/workflows/snap-store-publish-to-candidate.yml
+++ b/.github/workflows/snap-store-publish-to-candidate.yml
@@ -13,6 +13,12 @@ on:
         required: true
       LP_BUILD_SECRET:
         required: true
+      SNAPCRAFTERS_BOT_COMMIT:
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 # Permissions for GITHUB_TOKEN
 permissions:
@@ -26,13 +32,41 @@ env:
   CHANNEL: 'candidate'
 
 jobs:
+  get_archs:
+    name: Compute architectures
+    runs-on: ubuntu-latest
+    outputs:
+      archs: ${{ steps.archs.outputs.archs }}
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CHANNEL }}
+
+      - name: Compute architectures
+        id: archs
+        run: |
+          # Handle the case where architectures is a simple list of strings
+          archs="$(cat snap/snapcraft.yaml | yq -I=0 -o=json '[.architectures[]]')"
+
+          # Handle the case where architectures is a list of objects
+          if echo "$archs" | grep -q "build-on"; then
+              archs="$(cat snap/snapcraft.yaml | yq -I=0 -o=json '[.architectures[]."build-on"]')"
+          fi
+
+          echo "archs=$archs" >> "$GITHUB_OUTPUT"
+
   build:
     name: "Build & publish"
     environment: "Candidate Branch"
     runs-on: ubuntu-latest
+    needs: [get_archs]
     strategy:
       matrix:
-        architecture: ['amd64', 'arm64']
+        # Parse the list of architectures from the output we created above (one job per arch)
+        architecture: ${{ fromJSON(needs.get_archs.outputs.archs) }}
+    outputs:
+      version: ${{ steps.build.outputs.version }}
     steps:
       - name: Checkout the source
         uses: actions/checkout@v4
@@ -42,26 +76,32 @@ jobs:
       - name: Setup snapcraft
         env:
           LP_BUILD_SECRET: ${{ secrets.LP_BUILD_SECRET }}
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_CANDIDATE }}
         run: |
           sudo snap install snapcraft --classic
-          
+
           # Setup Launchpad credentials
           mkdir -p ~/.local/share/snapcraft/provider/launchpad
           echo "$LP_BUILD_SECRET" > ~/.local/share/snapcraft/provider/launchpad/credentials
           git config --global user.email "github-actions@github.com"
           git config --global user.name "Github Actions"
 
+          # Install moreutils so we have access to sponge
+          sudo apt-get update; sudo apt-get install -y moreutils
+
       - name: Remote build the snap
         id: build
         env:
           ARCHITECTURE: ${{ matrix.architecture }}
         run : |
+          # Remove the architecture definition from the snapcraft.yaml due to:
+          # https://bugs.launchpad.net/snapcraft/+bug/1885150
+          cat snap/snapcraft.yaml | yq 'del(.architectures)' | sponge snap/snapcraft.yaml
+
           snapcraft remote-build --launchpad-accept-public-upload --build-for=${ARCHITECTURE}
 
           version="$(cat snap/snapcraft.yaml | yq -r '.version')"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "snap=mattermost-desktop_${version}_${ARCHITECTURE}.snap" >> "$GITHUB_OUTPUT"
+          echo "snap=${{ env.SNAP_NAME }}_${version}_${ARCHITECTURE}.snap" >> "$GITHUB_OUTPUT"
 
       - name: Review the built snap
         uses: diddlesnaps/snapcraft-review-action@v1
@@ -73,26 +113,137 @@ jobs:
         id: publish
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_CANDIDATE }}
-          SNAP_NAME: ${{ steps.build.outputs.snap }}
+          SNAP_FILE: ${{ steps.build.outputs.snap }}
           ARCHITECTURE: ${{ matrix.architecture }}
         run: |
-          rev=$(snapcraft push $SNAP_NAME --release=$CHANNEL)
-          echo "revision_${ARCHITECTURE}=${rev}" >> $GITHUB_OUTPUT
-    outputs: 
-      revision_amd64: ${{ steps.publish.outputs.revision_amd64 }}
-      revision_arm64: ${{ steps.publish.outputs.revision_arm64 }}
-      version: ${{ steps.build.outputs.version }}
+          snapcraft push "$SNAP_FILE" --release="$CHANNEL"
+
+  # Create an issue using the template that asks maintainers to test the snap, and take
+  # action to promote the revisions to stable if testing is successful.
   create_issue:
     name: "Create call for testing"
+    environment: "Candidate Branch"
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: JasonEtco/create-an-issue@v2
+      - name: Checkout the source
+        uses: actions/checkout@v4
+      
+      - name: Setup snapcraft
+        run: |
+          sudo snap install snapcraft --classic
+
+      - name: Write the arch/rev table
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_CANDIDATE }}
+        id: build
+        run: |
+          # Build the initial structure for the HTML table including the header row.
+          table="<table><thead><tr><th>CPU Architecture</th><th>Revision</th></tr></thead><tbody>"
+
+          # Declare an array to keep track of the revisions we've seen
+          revisions=()
+
+          # Iterate over the architectures specified in the snapcraft.yaml
+          for arch in $(cat snap/snapcraft.yaml | yq '.architectures[]'); do
+              rev="$(snapcraft list-revisions "${{ env.SNAP_NAME }}" --arch "$arch" | grep "latest/candidate*" | head -n1 | cut -d' ' -f1)"
+              revisions+=("$rev")
+              # Add a row to the HTML table
+              table="${table}<tr><td>${arch}</td><td>${rev}</td></tr>"
+          done
+
+          # Add the closing tags for the table
+          table="${table}</tbody></table>"
+
+          # Get a comma separated list of revisions
+          printf -v joined '%s,' "${revisions[@]}"
+
+          echo "revisions=${joined%,}" >> "$GITHUB_OUTPUT"
+          echo "table=${table}" >> "$GITHUB_OUTPUT"
+
+      - name: Create call for testing issue
+        uses: JasonEtco/create-an-issue@v2
+        id: comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          revision_amd64: ${{ needs.build.outputs.revision_amd64 }}
-          revision_arm64: ${{ needs.build.outputs.revision_arm64 }}
+          revisions: ${{ steps.build.outputs.revisions }}
+          table: ${{ steps.build.outputs.table }}
           version: ${{ needs.build.outputs.version }}
         with:
           filename: .github/testing-issue-template.md
+    outputs:
+      issue_number: ${{ steps.comment.outputs.number }}
+
+  # Deploy the snap inside a desktop VM and grab screenshots of the desktop, and of
+  # the application, then post them as a comment on the issue created above.
+  grab-screenshots:
+    name: Gather screenshots
+    environment: "Candidate Branch"
+    needs: 
+      - build
+      - create_issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+
+      - name: Prepare VM
+        run: |
+          .github/vmctl prepare
+          .github/vmctl exec "sudo snap install ${{ env.SNAP_NAME }} --channel candidate"
+          .github/vmctl exec "snap run ${{ env.SNAP_NAME }} &>/home/ubuntu/${{ env.SNAP_NAME }}.log &"
+          sleep 20
+
+      - name: Gather screenshots
+        run: |
+          .github/vmctl screenshot-full
+          .github/vmctl screenshot-window
+
+      - name: Output application logs
+        run: |
+          .github/vmctl exec "cat /home/ubuntu/${{ env.SNAP_NAME }}.log"
+
+      - name: Checkout snapcrafters/ci-screenshots
+        uses: actions/checkout@v4
+        with: 
+          repository: snapcrafters/ci-screenshots
+          path: ci-screenshots
+          token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
+
+      - name: Upload screenshots to snapcrafters/ci-screenshots
+        id: screenshots
+        run: |
+          file_prefix="$(date +%Y%m%d)-${{ env.SNAP_NAME }}-${{ needs.create_issue.outputs.issue_number }}"
+
+          pushd ci-screenshots
+          mv ../screenshot-screen.png "${file_prefix}-screen.png"
+          mv ../screenshot-window.png "${file_prefix}-window.png"
+
+          git config --global user.email "merlijn.sebrechts+snapcrafters-bot@gmail.com"
+          git config --global user.name "Snapcrafters Bot"
+
+          git add -A .
+          git commit -m "data: screenshots for snapcrafters/${{ env.SNAP_NAME }}#${{ needs.create_issue.outputs.issue_number }}"
+          git push origin main
+
+          echo "screen=https://raw.githubusercontent.com/snapcrafters/ci-screenshots/main/${file_prefix}-screen.png" >> "$GITHUB_OUTPUT"
+          echo "window=https://raw.githubusercontent.com/snapcrafters/ci-screenshots/main/${file_prefix}-window.png" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on call for testing issue with screenshots
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: ${{ needs.create_issue.outputs.issue_number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `The following screenshots were taken during automated testing:
+
+              ![window](${{ steps.screenshots.outputs.window }})
+
+              ![screen](${{ steps.screenshots.outputs.screen }})
+              `
+            })

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -1,25 +1,31 @@
 name: 🧪 Test snap can be built on x86_64
 
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
-    
+    branches: [ "**" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Permissions for GITHUB_TOKEN
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - uses: snapcore/action-build@v1
+      - name: Build snap
+        uses: snapcore/action-build@v1
         id: build
 
-      - uses: diddlesnaps/snapcraft-review-action@v1
+      - name: Review snap
+        uses: diddlesnaps/snapcraft-review-action@v1
         with:
           snap: ${{ steps.build.outputs.snap }}
           isClassic: 'false'
-          # Plugs and Slots declarations to override default denial (requires store assertion to publish)
-          # plugs: ./plug-declaration.json
-          # slots: ./slot-declaration.json

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,10 +15,9 @@ grade: stable
 confinement: strict
 compression: lzo
 
-# Can't use it until this is fixed: https://bugs.launchpad.net/snapcraft/+bug/1885150
-# architectures:
-#  - build-on: amd64
-#  - build-on: arm64
+architectures:
+ - amd64
+ - arm64
 
 parts:
   mattermost-desktop:


### PR DESCRIPTION
Brings across changes from `signal-desktop` from the last two weeks:

- Auto-screenshot faciity
- New templates
- Some updated naming in CI
- Re-enable architectures in the snapcraft.yaml

@merlijn-sebrechts may need secrets updating before merging to allow pushing to the `ci-screenshots` repo.