### PR TITLE
Disable global shortcuts portal while it is broken in Chromium/Electron

### DIFF
--- a/snap/local/launcher.sh
+++ b/snap/local/launcher.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$SNAP/opt/Mattermost/mattermost-desktop" --no-sandbox --disable-seccomp-filter-sandbox --disable-features=GlobalShortcutsPortal

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,7 +54,7 @@ apps:
   mattermost-desktop:
     extensions: [gnome]
     command-chain: [opt/Mattermost/fix-default-download-dir]
-    command: opt/Mattermost/mattermost-desktop --no-sandbox --disable-seccomp-filter-sandbox
+    command: launcher.sh
     desktop: usr/share/applications/mattermost-desktop.desktop
     autostart: mattermost-desktop.desktop
     environment:


### PR DESCRIPTION
Need to create a launcher script because snapcraft/snapd do not support the equal '=' sign in a command definition!

Closes: #125 