### PR TITLE
fix: Ensure $WAYLAND_OPTS is set to something to guard against unbound variables.

### DIFF
--- a/snap/local/launcher.sh
+++ b/snap/local/launcher.sh
@@ -4,4 +4,4 @@ if [ -n "$WAYLAND_DISPLAY" ] && [ -z "$DISABLE_WAYLAND" ]; then
   WAYLAND_OPTS="--enable-features=UseOzonePlatform --ozone-platform-hint=auto"
 fi
 
-exec "$SNAP/opt/Mattermost/mattermost-desktop" --no-sandbox --disable-seccomp-filter-sandbox --disable-features=GlobalShortcutsPortal $WAYLAND_OPTS "$@"
+exec "$SNAP/opt/Mattermost/mattermost-desktop" --no-sandbox --disable-seccomp-filter-sandbox --disable-features=GlobalShortcutsPortal "${WAYLAND_OPTS:-}" "$@"

--- a/snap/local/launcher.sh
+++ b/snap/local/launcher.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+WAYLAND_OPTS=""
+
 if [ -n "$WAYLAND_DISPLAY" ] && [ -z "$DISABLE_WAYLAND" ]; then
   WAYLAND_OPTS="--enable-features=UseOzonePlatform --ozone-platform-hint=auto"
 fi

--- a/snap/local/launcher.sh
+++ b/snap/local/launcher.sh
@@ -1,2 +1,7 @@
 #!/bin/sh
-exec "$SNAP/opt/Mattermost/mattermost-desktop" --no-sandbox --disable-seccomp-filter-sandbox --disable-features=GlobalShortcutsPortal "$@"
+
+if [ -n "$WAYLAND_DISPLAY" ] && [ -z "$DISABLE_WAYLAND" ]; then
+  WAYLAND_OPTS="--enable-features=UseOzonePlatform --ozone-platform-hint=auto"
+fi
+
+exec "$SNAP/opt/Mattermost/mattermost-desktop" --no-sandbox --disable-seccomp-filter-sandbox --disable-features=GlobalShortcutsPortal $WAYLAND_OPTS "$@"


### PR DESCRIPTION
This should really be done by quoting the variable, but for some strange reason electron doesn't use the wayland backend when that variable is quoted. Even when the command passed looks exactly the same.
