### PR TITLE
Allow the user to enable Wayland

### DIFF
--- a/snap/local/launcher.sh
+++ b/snap/local/launcher.sh
@@ -1,9 +1,3 @@
 #!/bin/sh
 
-WAYLAND_OPTS=""
-
-if [ -n "$WAYLAND_DISPLAY" ] && [ -z "$DISABLE_WAYLAND" ]; then
-  WAYLAND_OPTS="--enable-features=UseOzonePlatform --ozone-platform-hint=auto"
-fi
-
-exec "$SNAP/opt/Mattermost/mattermost-desktop" --no-sandbox --disable-seccomp-filter-sandbox --disable-features=GlobalShortcutsPortal $WAYLAND_OPTS "$@"
+exec "$SNAP/opt/Mattermost/mattermost-desktop" --no-sandbox --disable-seccomp-filter-sandbox --disable-features=GlobalShortcutsPortal "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -61,7 +61,6 @@ apps:
       # Correct the TMPDIR path for Chromium Framework/Electron to
       # ensure libappindicator has readable resources
       TMPDIR: $XDG_RUNTIME_DIR
-      DISABLE_WAYLAND: 1
     plugs:
       - shmem
       - home


### PR DESCRIPTION
Forcing DISABLE_WAYLAND=1 makes the desktop command-chain hide the Wayland socket. If you then call mattermost-desktop with --ozone-platform-hint=auto or with env ELECTRON_OZONE_PLATFORM_HINT=wayland, chromium will crash instead of falling back to x11.

We can default to x11 while still allowing users to opt-in to Wayland by simply not specifying any additional environment variables.

Closes: https://github.com/snapcrafters/mattermost-desktop/issues/145