### PR TITLE
Consider publishing release candidate versions to candidate channel

### DIFF
--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -18,6 +18,15 @@ jobs:
       && contains(github.event.comment.body, '/promote ')
       && contains(github.event.*.labels.*.name, 'testing')
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Check version is not pre-release
+        run: |
+          if grep -qE '^version:.*(rc|beta|alpha)' snap/snapcraft.yaml; then
+            echo "Error: Cannot promote pre-release versions to stable"
+            exit 1
+          fi
+          echo "Version is stable, proceeding with promotion"
       - name: ⬆️ Promote to stable
         uses: snapcrafters/ci/promote-to-stable@main
         with:

--- a/.github/workflows/release-to-candidate.yaml
+++ b/.github/workflows/release-to-candidate.yaml
@@ -15,6 +15,25 @@ permissions:
   issues: write
 
 jobs:
+  check-version:
+    name: 🔍 Check if pre-release version
+    runs-on: ubuntu-latest
+    outputs:
+      is-prerelease: ${{ steps.check.outputs.is-prerelease }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Check version
+        id: check
+        run: |
+          if awk '/^version:/ {print "Version:", $2; exit ($2 ~ /(rc|beta|alpha)/)}' snap/snapcraft.yaml; then
+            echo "is-prerelease=false" >> $GITHUB_OUTPUT
+            echo "This is a stable version"
+          else
+            echo "is-prerelease=true" >> $GITHUB_OUTPUT
+            echo "This is a pre-release version"
+          fi
+
   get-architectures:
     name: 🖥 Get snap architectures
     runs-on: ubuntu-latest
@@ -45,7 +64,8 @@ jobs:
   
   call-for-testing:
     name: 📣 Create call for testing
-    needs: [release, get-architectures]
+    needs: [release, get-architectures, check-version]
+    if: needs.check-version.outputs.is-prerelease == 'false'
     environment: "Candidate Branch"
     runs-on: ubuntu-latest
     outputs:
@@ -60,7 +80,8 @@ jobs:
   
   screenshots:
     name: 📸 Gather screenshots
-    needs: call-for-testing
+    needs: [call-for-testing, check-version]
+    if: needs.check-version.outputs.is-prerelease == 'false'
     environment: "Candidate Branch"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -23,6 +23,6 @@ jobs:
           token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           update-script: |
             VERSION=$(curl -sL https://api.github.com/repos/mattermost/desktop/releases |\
-              jq . | grep tag_name | grep -v beta | grep -v rc | cut -d'"' -f4 | sort -r --version-sort | head -n1 | tr -d 'v'
+              jq -r 'sort_by(.published_at) | reverse | .[0].tag_name' | tr -d 'v'
             )
             sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml


### PR DESCRIPTION
The Mattermost Desktop app snap currently only allows users to install approved stable versions. Would you consider publishing release candidate versions to the candidate channel?

The existing flow would be identical, except release candidate versions would not be allowed for promotion to the stable channel. This would enable testing pre-release alpha, beta, and rc versions of the Mattermost desktop app by using the candidate channel.

This proposed PR introduces the following changes to make that happen:

- We update the target Mattermost desktop app version to match the latest released version, even if that version is an alpha, beta, or rc

- Those versions will be built and pushed to the candidate channel

- We have a check so that we only mark stable release versions as candidates for promotion to the stable channel

- We have an additional check to enforce that only stable release versions can be promoted to the stable channel

Thank you for all that you do in the Snapcraft ecosystem, and feel free to close this PR if it is not something you're looking to fold in :slightly_smiling_face: 