### PR TITLE
Fix use of gpu-2404

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,6 +54,17 @@ parts:
     source: snap/local
     source-type: local
 
+  # Needed because mesa-utils pulls in mesa libraries that conflict with the gpu-2404 interface
+  gpu-2404:
+    after:
+      - mattermost-desktop
+      - local-parts
+    source: https://github.com/canonical/gpu-snap.git
+    plugin: dump
+    override-prime: |
+      craftctl default
+      ${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404
+
 apps:
   mattermost-desktop:
     extensions: [gnome]


### PR DESCRIPTION
While testing the mesa-25.2.8 update for the mesa-2404 I discovered that this snap is not cleaning the mesa libraries. That results in the GUI not coming up: https://github.com/canonical/mesa-2404/issues/96

This corrects that problem.

With the fix, mattermost-desktop works with both, without it works with whichever matches the mesa libraries in the archive (currently 25.2.8, but in the store 25.0.7)

At the time of writing both mesa-25.0.7 and 25.2.8 are available from the mesa-2404 snap:

* latest/beta: 25.2.8-snap234 2026-02-10 (1417)
* latest/stable: 25.0.7-snap211 2025-11-05 (1165)

I will be promoting 25.2.8-snap234 to candidate and issuing a "call for testing" with a view to promoting to stable in a week.