### PR TITLE
fix: remove autostart

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,7 +73,6 @@ apps:
       - opt/Mattermost/fix-hardware-accel-with-no-renderer
     command: launcher.sh
     desktop: usr/share/applications/mattermost-desktop.desktop
-    autostart: mattermost-desktop.desktop
     environment:
       # Correct the TMPDIR path for Chromium Framework/Electron to
       # ensure libappindicator has readable resources


### PR DESCRIPTION
I find it rather odd that Mattermost launches automatically on every login by default when such behavior should be opt in. This PR removes the autostart entry so Mattermost behaves like users would expect: it runs when you open it, not before.

Users who want autostart can easily enable it themselves say via Gnome Startup Applications. Opting out requires knowing that `$SNAP_USER_DATA/.config/autostart` exists and manually deleting the desktop entry there, which most users won't think to do, and which may not survive a snap refresh.